### PR TITLE
Rewrite of the syntax file

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -29,7 +29,6 @@ syn match   nixComment '#.*' contains=nixTodo
 syn region  nixComment start=+/\*+ skip=+\\"+ end=+\*/+
 
 syn match  nixInterpolationParam '\k\+' contained
-syn match  nixInterpolation '\$\k\+' contained
 syn region nixInterpolation matchgroup=nixInterpolationDelimiter start="${" end="}" contained contains=nixInterpolationParam
 
 syn region nixString matchgroup=nixStringDelimiter start=+"+   skip=+\\"|\\\\+     end=+"+  contains=nixInterpolation

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -19,10 +19,6 @@ syn match   nixOperator '=='
 syn match   nixOperator '?'
 syn match   nixOperator '||'
 
-syn keyword nixFunction
-      \ currentSystem currentTime isFunction getEnv trace toPath pathExists
-      \ readFile toXML toFile filterSource attrNames getAttr hasAttr isAttrs
-      \ listToAttrs isList head tail add sub lessThan substring stringLength
 
 syn keyword nixTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 syn match   nixComment '#.*' contains=nixTodo
@@ -41,9 +37,27 @@ syn match nixArgument  "\k\+\ze\s*:/\@!"
 syn match nixAttribute "\%(\k\|\.\)\+\ze\s*==\@!" contains=nixAttributeDot
 syn match nixAttributeDot "\." contained
 
+" Non-namespaced Nix builtins as of version 1.10:
+syn keyword nixBuiltin
+      \ abort baseNameOf derivation dirOf fetchTarball import map removeAttrs
+      \ throw toString
+
+" Namespaced Nix builtins as of version 1.10:
+syn keyword nixNamespacedBuiltin contained
+      \ add all any attrNames attrValues compareVersions concatLists
+      \ currentSystem deepSeq div elem elemAt fetchurl filter filterSource
+      \ foldl' fromJSON genList getAttr getEnv hasAttr hashString head
+      \ intersectAttrs isAttrs isBool isFunction isInt isList isString length
+      \ lessThan listToAttrs mul parseDrvName pathExists readDir readFile
+      \ replaceStrings seq sort stringLength sub substring tail toFile toJSON
+      \ toPath toXML trace typeOf
+
+syn match nixBuiltin "builtins\.[a-zA-Z']\+" contains=nixNamespacedBuiltin
+
 hi def link nixArgument               Identifier
-hi def link nixFunction               Function
 hi def link nixAttribute              Identifier
+hi def link nixBuiltin                Special
+hi def link nixNamespacedBuiltin      Special
 hi def link nixAttributeDot           Normal
 hi def link nixBoolean                Boolean
 hi def link nixComment                Comment

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -58,3 +58,5 @@ hi def link nixPathDelimiter          Delimiter
 hi def link nixString                 String
 hi def link nixStringDelimiter        Delimiter
 hi def link nixTodo                   Todo
+
+let b:current_syntax = "nix"

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -7,38 +7,110 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn keyword nixBoolean     true false null
-syn keyword nixConditional if then else
-syn keyword nixKeyword     let in rec inherit with import throw
+syn keyword nixBoolean     true false
+syn keyword nixNull        null
+syn keyword nixRecKeyword  rec
 
 syn keyword nixOperator and or not
 syn match   nixOperator '!=\|!'
 syn match   nixOperator '&&'
-syn match   nixOperator '//'
+syn match   nixOperator '//\='
 syn match   nixOperator '=='
 syn match   nixOperator '?'
 syn match   nixOperator '||'
+syn match   nixOperator '++\='
+syn match   nixOperator '-'
+syn match   nixOperator '\*'
+syn match   nixOperator '->'
 
+syn match nixParen '[()]'
+syn match nixInteger '\d\+'
 
 syn keyword nixTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
-syn match   nixComment '#.*' contains=nixTodo
-syn region  nixComment start=+/\*+ skip=+\\"+ end=+\*/+
+syn match   nixComment '#.*' contains=nixTodo,@Spell
+syn region  nixComment start=+/\*+ end=+\*/+ contains=nixTodo,@Spell
 
-syn match  nixInterpolationParam '\k\+' contained
-syn region nixInterpolation matchgroup=nixInterpolationDelimiter start="${" end="}" contained contains=nixInterpolationParam
+syn region nixInterpolation matchgroup=nixInterpolationDelimiter start="\${" end="}" contained contains=@nixExpr,nixInterpolationParam
 
-syn region nixString matchgroup=nixStringDelimiter start=+"+   skip=+\\"|\\\\+     end=+"+  contains=nixInterpolation
-syn region nixString matchgroup=nixStringDelimiter start=+''+  skip=+'''\|''${\|"+ end=+''+ contains=nixInterpolation
+syn match nixSimpleStringSpecial /\\["nrt\\$]/ contained
+syn match nixInterpolationSpecial /''['$]/ contained
 
-syn match  nixPath "\%(:\|\.\|\k\)\+\/\%(:\|\.\|\/\|\k\)\+"
-syn region nixPath matchgroup=nixPathDelimiter start="<" end=">" contains=nixPath
+syn region nixSimpleString matchgroup=nixStringDelimiter start=+"+ skip=+\\"+ end=+"+ contains=nixInterpolation,nixSimpleStringSpecial
+syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$]+ end=+''+ contains=nixInterpolation,nixInterpolationSpecial
 
-syn match nixArgument  "\k\+\ze\s*:/\@!"
-syn match nixAttribute "\%(\k\|\.\)\+\ze\s*==\@!" contains=nixAttributeDot
+syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
+
+syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
+syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
+syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
+syn region nixSearchPathRef matchgroup=nixPathDelimiter start="<" end=">" contains=nixSearchPath
+syn match nixURI "[a-zA-Z][a-zA-Z0-9.+-]*:[a-zA-Z0-9%/?:@&=$,_.!~*'+-]\+"
+
 syn match nixAttributeDot "\." contained
+syn match nixAttribute "[a-zA-Z_][a-zA-Z0-9_'-]*" contained
+syn region nixAttributeAssignment start="=" end="\ze;" contained contains=@nixExpr
+syn region nixAttributeDefinition start=/\ze[a-zA-Z_"$]/ end=";" contained contains=nixComment,nixAttribute,nixInterpolation,nixSimpleString,nixAttributeDot,nixAttributeAssignment
+
+syn region nixInheritAttributeScope start="(" end=")" contained contains=nixComment,nixAttribute,nixAttributeDot
+syn region nixAttributeDefinition matchgroup=nixInherit start="\<inherit\>" matchgroup=NONE end=";" contained contains=nixComment,nixInheritAttributeScope,nixAttribute
+
+"syn region nixAttributeSet start="{\ze\_.\{-\}}\ze\%(\s\|\n\)*:\@!" end="}" contains=nixComment,nixAttributeDefinition
+syn region nixAttributeSet start="{" end="}" contains=nixComment,nixAttributeDefinition
+
+syn region nixArgumentDefinitionWithDefault matchgroup=nixArgumentDefinition start="[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*?\@=" matchgroup=NONE end="[,}]\@=" transparent contained contains=@nixExpr
+syn match nixArgumentDefinition "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*[,}]\@=" contained
+syn match nixArgumentEllipsis "\.\.\." contained
+syn match nixArgumentSeparator "," contained
+
+syn match nixArgOperator '@\s*[a-zA-Z_][a-zA-Z0-9_'-]*\s*:'he=s+1 contained contains=nixAttribute
+syn match nixArgOperator '[a-zA-Z_][a-zA-Z0-9_'-]*\s*@'hs=e-1 contains=nixAttribute nextgroup=nixFunctionArgument
+
+" This is a bit more complicated, because function arguments can be passed in a
+" very similar form on how attribute sets are defined and two regions with the
+" same start patterns will shadow each other. Instead of a region we could use a
+" match on {\_.\{-\}}, which unfortunately doesn't take nesting into account.
+"
+" So what we do instead is that we look forward until we are sure that it's a
+" function argument. Unfortunately, we need to catch comments and both vertical
+" and horizontal white space, which the following regex should hopefully do:
+"
+" "\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*"
+"
+" Fortunately the matching rules for function arguments are much simpler than
+" for real attribute sets, because we can stop when we hit the first ellipsis or
+" default value operator, but we also need to paste the "whitespace & comments
+" eating" regex all over the place (marked with 'v's):
+"
+" Region match 1: { foo ? ... } or { foo, ... } or { ... } (ellipsis)
+"                                         vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv   {----- identifier -----}vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn region nixFunctionArgument start="{\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*\%([a-zA-Z_][a-zA-Z0-9_'-]*\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*[,?}]\|\.\.\.\)" end="}" contains=nixComment,nixArgumentDefinitionWithDefault,nixArgumentDefinition,nixArgumentEllipsis,nixArgumentSeparator nextgroup=nixArgOperator
+
+" Now it gets more tricky, because we need to look forward for the colon, but
+" there could be something like "{}@foo:", even though it's highly unlikely.
+"
+" Region match 2: {}
+"                                         vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv@vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv{----- identifier -----}  vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn region nixFunctionArgument start="{\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*}\%(\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*@\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*[a-zA-Z_][a-zA-Z0-9_'-]*\)\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*:" end="}" contains=nixComment nextgroup=nixArgOperator
+
+syn match nixSimpleFunctionArgument "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*:/\@!"
+
+syn region nixList matchgroup=nixListBracket start="\[" end="\]" contains=@nixExpr
+
+syn region nixLetExpr matchgroup=nixLetExprKeyword start="\<let\>" end="\<in\>" contains=nixComment,nixAttributeDefinition
+
+syn keyword nixIfExprKeyword then contained
+syn region nixIfExpr matchgroup=nixIfExprKeyword start="\<if\>" end="\<else\>" contains=@nixExpr,nixIfExprKeyword
+
+syn region nixWithExpr matchgroup=nixWithExprKeyword start="\<with\>" matchgroup=NONE end=";" contains=@nixExpr
+
+syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathDef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr
+
+" These definitions override @nixExpr and have to come afterwards:
+
+syn match nixInterpolationParam "[a-zA-Z_][a-zA-Z0-9_'-]*\%(\.[a-zA-Z_][a-zA-Z0-9_'-]*\)*" contained
 
 " Non-namespaced Nix builtins as of version 1.10:
-syn keyword nixBuiltin
+syn keyword nixSimpleBuiltin
       \ abort baseNameOf derivation dirOf fetchTarball import map removeAttrs
       \ throw toString
 
@@ -52,25 +124,46 @@ syn keyword nixNamespacedBuiltin contained
       \ replaceStrings seq sort stringLength sub substring tail toFile toJSON
       \ toPath toXML trace typeOf
 
-syn match nixBuiltin "builtins\.[a-zA-Z']\+" contains=nixNamespacedBuiltin
+syn match nixBuiltin "builtins\.[a-zA-Z']\+"he=s+9 contains=nixComment,nixNamespacedBuiltin
 
-hi def link nixArgument               Identifier
+hi def link nixArgOperator            Operator
+hi def link nixArgumentDefinition     Identifier
+hi def link nixArgumentEllipsis       Operator
 hi def link nixAttribute              Identifier
-hi def link nixBuiltin                Special
-hi def link nixNamespacedBuiltin      Special
-hi def link nixAttributeDot           Normal
+hi def link nixAttributeDot           Operator
 hi def link nixBoolean                Boolean
+hi def link nixBuiltin                Special
 hi def link nixComment                Comment
 hi def link nixConditional            Conditional
+hi def link nixHomePath               Include
+hi def link nixIfExprKeyword          Keyword
+hi def link nixInherit                Keyword
+hi def link nixInteger                Integer
 hi def link nixInterpolation          Macro
 hi def link nixInterpolationDelimiter Delimiter
 hi def link nixInterpolationParam     Macro
-hi def link nixKeyword                Keyword
+hi def link nixInterpolationSpecial   Special
+hi def link nixLetExprKeyword         Keyword
+hi def link nixNamespacedBuiltin      Special
+hi def link nixNull                   Constant
 hi def link nixOperator               Operator
 hi def link nixPath                   Include
 hi def link nixPathDelimiter          Delimiter
+hi def link nixRecKeyword             Keyword
+hi def link nixSearchPath             Include
+hi def link nixSimpleBuiltin          Keyword
+hi def link nixSimpleFunctionArgument Identifier
+hi def link nixSimpleString           String
+hi def link nixSimpleStringSpecial    SpecialChar
 hi def link nixString                 String
 hi def link nixStringDelimiter        Delimiter
 hi def link nixTodo                   Todo
+hi def link nixURI                    Include
+hi def link nixWithExprKeyword        Keyword
+
+" This could lead up to slow syntax highlighting for large files, but usually
+" large files such as all-packages.nix are one large attribute set, so if we'd
+" use sync patterns we'd have to go back to the start of the file anyway
+syn sync fromstart
 
 let b:current_syntax = "nix"

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -39,11 +39,13 @@ syn match  nixPath "\%(:\|\.\|\k\)\+\/\%(:\|\.\|\/\|\k\)\+"
 syn region nixPath matchgroup=nixPathDelimiter start="<" end=">" contains=nixPath
 
 syn match nixArgument  "\k\+\ze\s*:/\@!"
-syn match nixAttribute "\k\+\ze\s*==\@!"
+syn match nixAttribute "\%(\k\|\.\)\+\ze\s*==\@!" contains=nixAttributeDot
+syn match nixAttributeDot "\." contained
 
 hi def link nixArgument               Identifier
 hi def link nixFunction               Function
 hi def link nixAttribute              Identifier
+hi def link nixAttributeDot           Normal
 hi def link nixBoolean                Boolean
 hi def link nixComment                Comment
 hi def link nixConditional            Conditional

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -41,7 +41,7 @@ Execute (syntax):
   AssertEqual SyntaxOf('foo'), 'nixAttribute'
 
 Given nix (string):
-  "https://github.com/${owner}/${repo}/archive/$rev.tar.gz"
+  "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"
 
 Execute (syntax):
   AssertEqual SyntaxOf('"'), 'nixStringDelimiter'
@@ -50,7 +50,7 @@ Execute (syntax):
   AssertEqual SyntaxOf('}'), 'nixInterpolationDelimiter'
   AssertEqual SyntaxOf('owner'), 'nixInterpolationParam'
   AssertEqual SyntaxOf('repo'), 'nixInterpolationParam'
-  AssertEqual SyntaxOf('rev'), 'nixInterpolation'
+  AssertEqual SyntaxOf('rev'), 'nixInterpolationParam'
 
 Given nix (path):
   https://github.com/LnL7/vim-nix

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -21,7 +21,7 @@ Given nix (list):
     foo = [
       a
       b
-    ]
+    ];
   }
 
 Do (reindent):
@@ -33,7 +33,7 @@ Expect (indentation):
     foo = [
       a
       b
-    ]
+    ];
   }
 ~~~~~~~
 

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -16,6 +16,64 @@ Expect (indentation):
 Execute (syntax):
   AssertEqual SyntaxOf('foo'), 'nixAttribute'
 
+Given nix (attribute-path):
+  {
+    a.b.c = 2;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('a'), 'nixAttribute'
+  AssertEqual SyntaxOf('b'), 'nixAttribute'
+  AssertEqual SyntaxOf('c'), 'nixAttribute'
+  AssertEqual SyntaxOf('2'), 'nixInteger'
+
+Given nix (attribute-path-lots-of-spacing):
+  {
+    a
+    .
+    b
+    .
+    c
+    =
+    2
+    ;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('a'), 'nixAttribute'
+  AssertEqual SyntaxOf('b'), 'nixAttribute'
+  AssertEqual SyntaxOf('c'), 'nixAttribute'
+  AssertEqual SyntaxOf('2'), 'nixInteger'
+
+Given nix (attribute-nested):
+  {
+    a = {
+      b = {
+        c = "2}";
+      };
+    };
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('a'), 'nixAttribute'
+  AssertEqual SyntaxOf('b'), 'nixAttribute'
+  AssertEqual SyntaxOf('c'), 'nixAttribute'
+  AssertEqual SyntaxOf('2}'), 'nixSimpleString'
+
+Given nix (attribute-inherit):
+  {
+    inherit (a.b.c) foo;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('inherit'), 'nixInherit'
+  AssertEqual SyntaxOf('('), 'nixInheritAttributeScope'
+  AssertEqual SyntaxOf(')'), 'nixInheritAttributeScope'
+  AssertEqual SyntaxOf('a'), 'nixAttribute'
+  AssertEqual SyntaxOf('b'), 'nixAttribute'
+  AssertEqual SyntaxOf('c'), 'nixAttribute'
+  AssertEqual SyntaxOf('foo'), 'nixAttribute'
+
 Given nix (list):
   {
     foo = [
@@ -39,32 +97,51 @@ Expect (indentation):
 
 Execute (syntax):
   AssertEqual SyntaxOf('foo'), 'nixAttribute'
+  AssertEqual SyntaxOf('a'), 'nixFunctionCall'
+  AssertEqual SyntaxOf('b'), 'nixFunctionCall'
 
 Given nix (string):
   "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"
 
 Execute (syntax):
   AssertEqual SyntaxOf('"'), 'nixStringDelimiter'
-  AssertEqual SyntaxOf('https'), 'nixString'
+  AssertEqual SyntaxOf('https'), 'nixSimpleString'
   AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
   AssertEqual SyntaxOf('}'), 'nixInterpolationDelimiter'
   AssertEqual SyntaxOf('owner'), 'nixInterpolationParam'
   AssertEqual SyntaxOf('repo'), 'nixInterpolationParam'
   AssertEqual SyntaxOf('rev'), 'nixInterpolationParam'
 
-Given nix (path):
+Given nix (multiline-string):
+  ''
+    line1 ${ref1}
+    ${ref2} line2
+    line3 ${ref3}
+  ''
+
+Execute (syntax):
+  AssertEqual SyntaxOf('line1'), 'nixString'
+  AssertEqual SyntaxOf('line2'), 'nixString'
+  AssertEqual SyntaxOf('line3'), 'nixString'
+  AssertEqual SyntaxOf('ref1'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref2'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref3'), 'nixInterpolationParam'
+
+Given nix (url):
   https://github.com/LnL7/vim-nix
 
 Execute (syntax):
-  AssertEqual SyntaxOf('https'), 'nixPath'
-  AssertEqual SyntaxOf('github'), 'nixPath'
-  AssertEqual SyntaxOf('nix'), 'nixPath'
+  AssertEqual SyntaxOf('https'), 'nixURI'
+  AssertEqual SyntaxOf('github'), 'nixURI'
+  AssertEqual SyntaxOf('nix'), 'nixURI'
 
 Given nix (let):
   let
     foo = true;
     bar = false;
-  in foo
+  in {
+    result = foo && bar;
+  }
 
 Do (reindent):
   vip=
@@ -74,23 +151,127 @@ Expect (indentation):
   let
     foo = true;
     bar = false;
-  in foo
+  in {
+    result = foo && bar;
+  }
 ~~~~~~~
 
 Execute (syntax):
-  AssertEqual SyntaxOf('let'), 'nixKeyword'
-  AssertEqual SyntaxOf('in'), 'nixKeyword'
+  AssertEqual SyntaxOf('let'), 'nixLetExprKeyword'
+  AssertEqual SyntaxOf('in'), 'nixLetExprKeyword'
   AssertEqual SyntaxOf('foo'), 'nixAttribute'
   AssertEqual SyntaxOf('bar'), 'nixAttribute'
+  AssertEqual SyntaxOf('result'), 'nixAttribute'
+  AssertEqual SyntaxOf('&&'), 'nixOperator'
 
 Given nix (builtins):
-  hashString (builtins.fetchurl (toString "abort"))
+  builtins.doesntexist (hashString (builtins.fetchurl (toString "abort")))
 
 Execute (syntax):
+  AssertNotEqual SyntaxOf('doesntexist'), 'nixBuiltin'
   AssertNotEqual SyntaxOf('hashString'), 'nixBuiltin'
   AssertNotEqual SyntaxOf('hashString'), 'nixNamespacedBuiltin'
   AssertEqual SyntaxOf('builtins'), 'nixBuiltin'
   AssertEqual SyntaxOf('\.'), 'nixBuiltin'
   AssertEqual SyntaxOf('fetchurl'), 'nixNamespacedBuiltin'
-  AssertEqual SyntaxOf('toString'), 'nixBuiltin'
-  AssertEqual SyntaxOf('abort'), 'nixString'
+  AssertEqual SyntaxOf('toString'), 'nixSimpleBuiltin'
+  AssertEqual SyntaxOf('abort'), 'nixSimpleString'
+
+Given nix (simple-string-escape):
+  "foo\nbar\"end\${xxx}"
+
+Execute (syntax):
+  AssertEqual SyntaxAt(1, 1), 'nixStringDelimiter'
+  AssertEqual SyntaxOf('foo'), 'nixSimpleString'
+  AssertEqual SyntaxOf('\\n'), 'nixSimpleStringSpecial'
+  AssertEqual SyntaxOf('bar'), 'nixSimpleString'
+  AssertEqual SyntaxOf('\\"'), 'nixSimpleStringSpecial'
+  AssertEqual SyntaxOf('end'), 'nixSimpleString'
+  AssertEqual SyntaxOf('\$'), 'nixSimpleStringSpecial'
+  AssertEqual SyntaxOf('{'), 'nixSimpleString'
+  AssertEqual SyntaxOf('xxx'), 'nixSimpleString'
+  AssertEqual SyntaxOf('}'), 'nixSimpleString'
+  AssertEqual SyntaxAt(1, 22), 'nixStringDelimiter'
+
+Given nix (multiline-string-escape):
+  ''
+    foo'''bar
+    ''${xxx}
+  ''
+
+Execute (syntax):
+  AssertEqual SyntaxOf('foo'), 'nixString'
+  AssertEqual SyntaxOf("'''"), 'nixInterpolationSpecial'
+  AssertEqual SyntaxOf('bar'), 'nixString'
+  AssertEqual SyntaxOf("''\\$"), 'nixInterpolationSpecial'
+  AssertEqual SyntaxOf('{'), 'nixString'
+  AssertEqual SyntaxOf('xxx'), 'nixString'
+  AssertEqual SyntaxOf('}'), 'nixString'
+
+Given nix (lambda-attrs):
+  { # very descriptive comment
+    foo ? # another comment
+    /* yet another comment */
+    # default value here:
+    1
+  , bar ? "xxx"
+  , yyy
+  , ...
+  }: {
+    result = null;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('very descriptive comment'), 'nixComment'
+  AssertEqual SyntaxOf('foo'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('?'), 'nixOperator'
+  AssertEqual SyntaxOf('another comment'), 'nixComment'
+  AssertEqual SyntaxOf('yet another comment'), 'nixComment'
+  AssertEqual SyntaxOf('default value here:'), 'nixComment'
+  AssertEqual SyntaxOf('1'), 'nixInteger'
+  AssertEqual SyntaxOf('bar'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('xxx'), 'nixSimpleString'
+  AssertEqual SyntaxOf('yyy'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('\.\.\.'), 'nixArgumentEllipsis'
+  AssertEqual SyntaxOf('result'), 'nixAttribute'
+  AssertEqual SyntaxOf('null'), 'nixNull'
+
+Given nix (ifexpr):
+  if true then 111 else { a = 222; }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('if'), 'nixIfExprKeyword'
+  AssertEqual SyntaxOf('true'), 'nixBoolean'
+  AssertEqual SyntaxOf('then'), 'nixIfExprKeyword'
+  AssertEqual SyntaxOf('111'), 'nixInteger'
+  AssertEqual SyntaxOf('else'), 'nixIfExprKeyword'
+  AssertEqual SyntaxOf('a'), 'nixAttribute'
+  AssertEqual SyntaxOf('222'), 'nixInteger'
+
+Given nix (with-expr):
+  with foo; withfoo
+
+Execute (syntax):
+  AssertEqual SyntaxOf('with'), 'nixWithExprKeyword'
+  AssertEqual SyntaxOf('foo'), 'nixFunctionCall'
+  AssertEqual SyntaxOf('withfoo'), 'nixFunctionCall'
+
+Given nix (funarg-let-attrset):
+  { xxx ? null }@yyy:
+
+  bbb@{ ccc, ... }:
+
+  let foo = 11; in let xxx = 22; in {
+    bar = foo + zzz;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('xxx'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('?'), 'nixOperator'
+  AssertEqual SyntaxOf('null'), 'nixNull'
+  AssertEqual SyntaxOf('@'), 'nixArgOperator'
+  AssertEqual SyntaxOf('yyy'), 'nixAttribute'
+  AssertEqual SyntaxOf('bbb'), 'nixAttribute'
+  AssertEqual SyntaxOf('ccc'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('let'), 'nixLetExprKeyword'
+  AssertEqual SyntaxOf('bar'), 'nixAttribute'

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -82,3 +82,15 @@ Execute (syntax):
   AssertEqual SyntaxOf('in'), 'nixKeyword'
   AssertEqual SyntaxOf('foo'), 'nixAttribute'
   AssertEqual SyntaxOf('bar'), 'nixAttribute'
+
+Given nix (builtins):
+  hashString (builtins.fetchurl (toString "abort"))
+
+Execute (syntax):
+  AssertNotEqual SyntaxOf('hashString'), 'nixBuiltin'
+  AssertNotEqual SyntaxOf('hashString'), 'nixNamespacedBuiltin'
+  AssertEqual SyntaxOf('builtins'), 'nixBuiltin'
+  AssertEqual SyntaxOf('\.'), 'nixBuiltin'
+  AssertEqual SyntaxOf('fetchurl'), 'nixNamespacedBuiltin'
+  AssertEqual SyntaxOf('toString'), 'nixBuiltin'
+  AssertEqual SyntaxOf('abort'), 'nixString'


### PR DESCRIPTION
The goal here is to get syntax highlighting to be more correct, adhering more to the AST of the language itself rather than just blindly matching simple patterns or keywords.

However, most toplevel syntactic elements such as function calls (more or less whitespace-separated Nix expressions) currently are matched in a dumb "catch everything and hope it's more or less correct" way rather than following the upstream parser of Nix.

Right now the implementation works "well enough" for all of the Nix expression files I've tested, though I have to admit that my tests were by no means exhaustive but I did test fairly complex Nix expression
files.

In the long run it would be desirable to have a complete set of syntax rules here, so we can also detect errors from just the syntax highlighting rules.

The rules for paths and identifiers are now the same as in [libexpr/lexer.l](https://github.com/NixOS/nix/blob/d1e3bf01bce7d8502610532077f6f55c3df4de2c/src/libexpr/lexer.l) from Nix itself, so for example, highlighting paths should be more strict and close to what the evaluator expects.

@LnL7: You might also want to take a look at https://github.com/MarcWeber/vim-addon-nix, which has a few more features than just syntax highlighting (for example checking code with `nix-instantiate`). So maybe you want to join forces.