### PR TITLE
Add test.nix file to make testing easier with Nix.

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,28 @@
+with import <nixpkgs> {};
+
+let
+  vader = fetchFromGitHub {
+    owner = "junegunn";
+    repo = "vader.vim";
+    rev = "ad2c752435baba9e7544d0046f0277c3573439bd";
+    sha256 = "0yvnah4lxk5w5qidc3y5nvl6lpi8rcv26907b3w7vjskqc935b8f";
+  };
+
+  src = ./.;
+
+  rcFile = writeText "vimrc" ''
+    filetype off
+    set rtp+=${vader}
+    set rtp+=${src}
+    filetype plugin indent on
+    syntax enable
+  '';
+
+  run = ''
+    ${vim}/bin/vim -XNu '${rcFile}' -i NONE \
+      -c 'Vader! ${src}/test/*.vader' > /dev/null
+  '';
+
+in runCommand "vim-nix-test.log" {} ''
+  (${run}) 2>&1 | tee "$out" >&2
+''


### PR DESCRIPTION
This allows to just run `nix-build test.nix` and we get a Vim version with isolated dependencies and just Vader and nothing more.

I've used this mainly because on my setup I'm patching in Vim plugins into the default `vimrc` itself rather than having a dotfile or a system-wide file.

So this should avoid any clashes with existing plugins or the stock Vim initialization file.