### PR TITLE
syntax: Merge non-namespaced+namespaced builtins.

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -114,15 +114,16 @@ syn keyword nixSimpleBuiltin
       \ abort baseNameOf derivation dirOf fetchTarball import map removeAttrs
       \ throw toString
 
-" Namespaced Nix builtins as of version 1.10:
+" Namespaced and non-namespaced Nix builtins as of version 1.10:
 syn keyword nixNamespacedBuiltin contained
-      \ add all any attrNames attrValues compareVersions concatLists
-      \ currentSystem deepSeq div elem elemAt fetchurl filter filterSource
-      \ foldl' fromJSON genList getAttr getEnv hasAttr hashString head
-      \ intersectAttrs isAttrs isBool isFunction isInt isList isString length
-      \ lessThan listToAttrs mul parseDrvName pathExists readDir readFile
-      \ replaceStrings seq sort stringLength sub substring tail toFile toJSON
-      \ toPath toXML trace typeOf
+      \ abort add all any attrNames attrValues baseNameOf compareVersions
+      \ concatLists currentSystem deepSeq derivation dirOf div elem elemAt
+      \ fetchTarball fetchurl filter filterSource foldl' fromJSON genList
+      \ getAttr getEnv hasAttr hashString head import intersectAttrs isAttrs
+      \ isBool isFunction isInt isList isString length lessThan listToAttrs map
+      \ mul parseDrvName pathExists readDir readFile removeAttrs replaceStrings
+      \ seq sort stringLength sub substring tail throw toFile toJSON toPath
+      \ toString toXML trace typeOf
 
 syn match nixBuiltin "builtins\.[a-zA-Z']\+"he=s+9 contains=nixComment,nixNamespacedBuiltin
 

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -165,10 +165,13 @@ Execute (syntax):
   AssertEqual SyntaxOf('&&'), 'nixOperator'
 
 Given nix (builtins):
-  builtins.doesntexist (hashString (builtins.fetchurl (toString "abort")))
+  builtins.doesntexist (builtins.map id [
+    hashString (builtins.fetchurl (toString "abort"))
+  ])
 
 Execute (syntax):
   AssertNotEqual SyntaxOf('doesntexist'), 'nixBuiltin'
+  AssertEqual SyntaxOf('map'), 'nixNamespacedBuiltin'
   AssertNotEqual SyntaxOf('hashString'), 'nixBuiltin'
   AssertNotEqual SyntaxOf('hashString'), 'nixNamespacedBuiltin'
   AssertEqual SyntaxOf('builtins'), 'nixBuiltin'


### PR DESCRIPTION
Just stumbled over this in a Nix expression file at:

https://github.com/NixOS/nixpkgs/blob/b843e7c50a3e9793625c4ed5af890a58a9620074/nixos/modules/installer/cd-dvd/iso-image.nix#L35

After confirming this with `nix-repl`, it's indeed the case that the `builtins.*` namespace also contains the non-namespaced primops.

The reason why I didn't add `nixSimpleBuiltin` to the `contains=` attribute for `nixBuiltin` is that we want to have the same highlighting as for `nixNamespacedBuiltin`.