### PR TITLE
More syntax improvements and fixes

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -112,7 +112,7 @@ syn region nixWithExpr matchgroup=nixWithExprKeyword start="\<with\>" matchgroup
 
 syn region nixAssertExpr matchgroup=nixAssertKeyword start="\<assert\>" matchgroup=NONE end=";" contains=@nixExpr
 
-syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathDef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr
+syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathRef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr
 
 " These definitions override @nixExpr and have to come afterwards:
 

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -11,7 +11,7 @@ syn keyword nixBoolean     true false
 syn keyword nixNull        null
 syn keyword nixRecKeyword  rec
 
-syn keyword nixOperator and or not
+syn keyword nixOperator or
 syn match   nixOperator '!=\|!'
 syn match   nixOperator '&&'
 syn match   nixOperator '//\='

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -56,13 +56,18 @@ syn region nixAttributeDefinition matchgroup=nixInherit start="\<inherit\>" matc
 
 syn region nixAttributeSet start="{" end="}" contains=nixComment,nixAttributeDefinition
 
-syn region nixArgumentDefinitionWithDefault matchgroup=nixArgumentDefinition start="[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*?\@=" matchgroup=NONE end="[,}]\@=" transparent contained contains=@nixExpr
-syn match nixArgumentDefinition "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*[,}]\@=" contained
+"                                                                                                              vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn region nixArgumentDefinitionWithDefault matchgroup=nixArgumentDefinition start="[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*?\@=" matchgroup=NONE end="[,}]\@=" transparent contained contains=@nixExpr
+"                                                           vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn match nixArgumentDefinition "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*[,}]\@=" contained
 syn match nixArgumentEllipsis "\.\.\." contained
 syn match nixArgumentSeparator "," contained
 
-syn match nixArgOperator '@\s*[a-zA-Z_][a-zA-Z0-9_'-]*\s*:'he=s+1 contained contains=nixAttribute
-syn match nixArgOperator '[a-zA-Z_][a-zA-Z0-9_'-]*\s*@'hs=e-1 contains=nixAttribute nextgroup=nixFunctionArgument
+"                          vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv                        vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn match nixArgOperator '@\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*[a-zA-Z_][a-zA-Z0-9_'-]*\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*:'he=s+1 contained contains=nixAttribute
+
+"                                                 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn match nixArgOperator '[a-zA-Z_][a-zA-Z0-9_'-]*\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*@'hs=e-1 contains=nixAttribute nextgroup=nixFunctionArgument
 
 " This is a bit more complicated, because function arguments can be passed in a
 " very similar form on how attribute sets are defined and two regions with the
@@ -74,6 +79,8 @@ syn match nixArgOperator '[a-zA-Z_][a-zA-Z0-9_'-]*\s*@'hs=e-1 contains=nixAttrib
 " and horizontal white space, which the following regex should hopefully do:
 "
 " "\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*"
+"
+" It is also used throught the whole file and is marked with 'v's as well.
 "
 " Fortunately the matching rules for function arguments are much simpler than
 " for real attribute sets, because we can stop when we hit the first ellipsis or
@@ -91,7 +98,8 @@ syn region nixFunctionArgument start="{\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)
 "                                         vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv@vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv{----- identifier -----}  vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 syn region nixFunctionArgument start="{\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*}\%(\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*@\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*[a-zA-Z_][a-zA-Z0-9_'-]*\)\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*:" end="}" contains=nixComment nextgroup=nixArgOperator
 
-syn match nixSimpleFunctionArgument "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*:/\@!"
+"                                                               vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+syn match nixSimpleFunctionArgument "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*:/\@!"
 
 syn region nixList matchgroup=nixListBracket start="\[" end="\]" contains=@nixExpr
 

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -110,7 +110,9 @@ syn region nixIfExpr matchgroup=nixIfExprKeyword start="\<if\>" end="\<else\>" c
 
 syn region nixWithExpr matchgroup=nixWithExprKeyword start="\<with\>" matchgroup=NONE end=";" contains=@nixExpr
 
-syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathDef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr
+syn region nixAssertExpr matchgroup=nixAssertKeyword start="\<assert\>" matchgroup=NONE end=";" contains=@nixExpr
+
+syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathDef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr
 
 " These definitions override @nixExpr and have to come afterwards:
 
@@ -137,6 +139,7 @@ syn match nixBuiltin "builtins\.[a-zA-Z']\+"he=s+9 contains=nixComment,nixNamesp
 hi def link nixArgOperator            Operator
 hi def link nixArgumentDefinition     Identifier
 hi def link nixArgumentEllipsis       Operator
+hi def link nixAssertKeyword          Keyword
 hi def link nixAttribute              Identifier
 hi def link nixAttributeDot           Operator
 hi def link nixBoolean                Boolean

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -54,7 +54,6 @@ syn region nixAttributeDefinition start=/\ze[a-zA-Z_"$]/ end=";" contained conta
 syn region nixInheritAttributeScope start="(" end=")" contained contains=nixComment,nixAttribute,nixAttributeDot
 syn region nixAttributeDefinition matchgroup=nixInherit start="\<inherit\>" matchgroup=NONE end=";" contained contains=nixComment,nixInheritAttributeScope,nixAttribute
 
-"syn region nixAttributeSet start="{\ze\_.\{-\}}\ze\%(\s\|\n\)*:\@!" end="}" contains=nixComment,nixAttributeDefinition
 syn region nixAttributeSet start="{" end="}" contains=nixComment,nixAttributeDefinition
 
 syn region nixArgumentDefinitionWithDefault matchgroup=nixArgumentDefinition start="[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%(\s\|\n\)*?\@=" matchgroup=NONE end="[,}]\@=" transparent contained contains=@nixExpr

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -266,6 +266,16 @@ Execute (syntax):
   AssertEqual SyntaxOf('foo'), 'nixFunctionCall'
   AssertEqual SyntaxOf('withfoo'), 'nixFunctionCall'
 
+Given nix (assert-expr):
+  assert true -> false; null
+
+Execute (syntax):
+  AssertEqual SyntaxOf('assert'), 'nixAssertKeyword'
+  AssertEqual SyntaxOf('true'), 'nixBoolean'
+  AssertEqual SyntaxOf('->'), 'nixOperator'
+  AssertEqual SyntaxOf('false'), 'nixBoolean'
+  AssertEqual SyntaxOf('null'), 'nixNull'
+
 Given nix (funarg-let-attrset):
   { xxx ? null }@yyy:
 

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -137,6 +137,26 @@ Execute (syntax):
   AssertEqual SyntaxOf('github'), 'nixURI'
   AssertEqual SyntaxOf('nix'), 'nixURI'
 
+Given nix (nix-search-path):
+  assert <foo-bar/blah/xxx.nix>;
+
+Execute (syntax):
+  AssertEqual SyntaxOf('<'), 'nixPathDelimiter'
+  AssertEqual SyntaxOf('foo'), 'nixSearchPath'
+  AssertEqual SyntaxOf('-'), 'nixSearchPath'
+  AssertEqual SyntaxOf('bar'), 'nixSearchPath'
+  AssertEqual SyntaxOf('/'), 'nixSearchPath'
+  AssertEqual SyntaxOf('\.'), 'nixSearchPath'
+  AssertEqual SyntaxOf('>'), 'nixPathDelimiter'
+
+Given nix (nix-paths):
+  [ ~/homefile ./. /etc/passwd ]
+
+Execute (syntax):
+  AssertEqual SyntaxOf('\~/homefile'), 'nixHomePath'
+  AssertEqual SyntaxOf('\./\.'), 'nixPath'
+  AssertEqual SyntaxOf('/etc/passwd'), 'nixPath'
+
 Given nix (let):
   let
     foo = true;

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -32,8 +32,8 @@ Given nix (attribute-path-lots-of-spacing):
     a
     .
     b
-    .
-    c
+    .#nastycomment
+    x
     =
     2
     ;
@@ -42,7 +42,9 @@ Given nix (attribute-path-lots-of-spacing):
 Execute (syntax):
   AssertEqual SyntaxOf('a'), 'nixAttribute'
   AssertEqual SyntaxOf('b'), 'nixAttribute'
-  AssertEqual SyntaxOf('c'), 'nixAttribute'
+  AssertEqual SyntaxAt(5, 3), 'nixAttributeDot'
+  AssertEqual SyntaxOf('nastycomment'), 'nixComment'
+  AssertEqual SyntaxOf('x'), 'nixAttribute'
   AssertEqual SyntaxOf('2'), 'nixInteger'
 
 Given nix (attribute-nested):
@@ -213,12 +215,15 @@ Execute (syntax):
 
 Given nix (lambda-attrs):
   { # very descriptive comment
-    foo ? # another comment
+    foo
+    /**/
+    ? # another comment
     /* yet another comment */
     # default value here:
     1
   , bar ? "xxx"
   , yyy
+  # last comment
   , ...
   }: {
     result = null;
@@ -228,6 +233,7 @@ Execute (syntax):
   AssertEqual SyntaxOf('very descriptive comment'), 'nixComment'
   AssertEqual SyntaxOf('foo'), 'nixArgumentDefinition'
   AssertEqual SyntaxOf('?'), 'nixOperator'
+  AssertEqual SyntaxOf('/\*\*/'), 'nixComment'
   AssertEqual SyntaxOf('another comment'), 'nixComment'
   AssertEqual SyntaxOf('yet another comment'), 'nixComment'
   AssertEqual SyntaxOf('default value here:'), 'nixComment'
@@ -235,6 +241,7 @@ Execute (syntax):
   AssertEqual SyntaxOf('bar'), 'nixArgumentDefinition'
   AssertEqual SyntaxOf('xxx'), 'nixSimpleString'
   AssertEqual SyntaxOf('yyy'), 'nixArgumentDefinition'
+  AssertEqual SyntaxOf('last comment'), 'nixComment'
   AssertEqual SyntaxOf('\.\.\.'), 'nixArgumentEllipsis'
   AssertEqual SyntaxOf('result'), 'nixAttribute'
   AssertEqual SyntaxOf('null'), 'nixNull'


### PR DESCRIPTION
This contains the following fixes and improvements:

  * Add highlighting for `assert`.
  * Fix highlighting of Nix search paths (`<foo>`).
  * Better handling of comments within lookahead/lookbehind
  * Remove `and` and `or`, which are not valid in Nix.
  * Write a few more tests.