### PR TITLE
test: Fix Nix expression file

### DIFF
--- a/test/default.nix
+++ b/test/default.nix
@@ -8,7 +8,7 @@ let
     sha256 = "0yvnah4lxk5w5qidc3y5nvl6lpi8rcv26907b3w7vjskqc935b8f";
   };
 
-  src = ./.;
+  src = ./..;
 
   rcFile = writeText "vimrc" ''
     filetype off


### PR DESCRIPTION
Regression introduced by e7c11195c945747d9323a8afa961d83bbfaf7ec5.

The commit moved the Nix expression file to the test/ subdirectory without changing the reference to the root of the project.