### PR TITLE
syntax: Fix matching < and > operators

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -13,6 +13,8 @@ syn keyword nixRecKeyword  rec
 
 syn keyword nixOperator or
 syn match   nixOperator '!=\|!'
+syn match   nixOperator '<=\?'
+syn match   nixOperator '>=\?'
 syn match   nixOperator '&&'
 syn match   nixOperator '//\='
 syn match   nixOperator '=='
@@ -43,7 +45,8 @@ syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
-syn region nixSearchPathRef matchgroup=nixPathDelimiter start="<" end=">" contains=nixSearchPath
+syn match nixPathDelimiter "[<>]" contained
+syn match nixSearchPathRef "<[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*>" contains=nixSearchPath,nixPathDelimiter
 syn match nixURI "[a-zA-Z][a-zA-Z0-9.+-]*:[a-zA-Z0-9%/?:@&=$,_.!~*'+-]\+"
 
 syn match nixAttributeDot "\." contained

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -315,3 +315,20 @@ Execute (syntax):
   AssertEqual SyntaxOf('ccc'), 'nixArgumentDefinition'
   AssertEqual SyntaxOf('let'), 'nixLetExprKeyword'
   AssertEqual SyntaxOf('bar'), 'nixAttribute'
+
+Given nix (searchpath-versus-lt):
+  {
+    alwaysTrue = 4 < 5;
+    alwaysFalse = 4 > 5;
+    somePath = <foo/bar>;
+    tailTrue = 4 <= 5;
+    tailFalse = 4 >= 5;
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('alwaysTrue.*\zs<'), 'nixOperator'
+  AssertEqual SyntaxOf('alwaysFalse.*\zs>'), 'nixOperator'
+  AssertEqual SyntaxOf('somePath.*\zs<'), 'nixPathDelimiter'
+  AssertEqual SyntaxOf('somePath.*\zs>'), 'nixPathDelimiter'
+  AssertEqual SyntaxOf('tailTrue.*\zs<'), 'nixOperator'
+  AssertEqual SyntaxOf('tailFalse.*\zs>'), 'nixOperator'


### PR DESCRIPTION
So far a search path reference has been a syntax region, which is a very lax match for the strict rules from the actual Nix expression parser and if there is a single `<` operator, the syntax highlighting for the rest of the file is going to be messed up.

Let's turn it into a `syn match` and highlight via the subgroups.

Of course, this also matches the operators we actually want to match, which are `<`, `>`, `<=` and `>=`.