### PR TITLE
match some specials

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -35,10 +35,10 @@ syn region  nixComment start=+/\*+ end=+\*/+ contains=nixTodo,@Spell
 syn region nixInterpolation matchgroup=nixInterpolationDelimiter start="\${" end="}" contained contains=@nixExpr,nixInterpolationParam
 
 syn match nixSimpleStringSpecial /\\["nrt\\$]/ contained
-syn match nixInterpolationSpecial /''['$]/ contained
+syn match nixInterpolationSpecial /''['$\\]/ contained
 
 syn region nixSimpleString matchgroup=nixStringDelimiter start=+"+ skip=+\\"+ end=+"+ contains=nixInterpolation,nixSimpleStringSpecial
-syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$]+ end=+''+ contains=nixInterpolation,nixInterpolationSpecial
+syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ end=+''+ contains=nixInterpolation,nixInterpolationSpecial
 
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 


### PR DESCRIPTION
inline heredoc style makefile breaks string highlighting; this fix adds the `\` in interpolated strings