### PR TITLE
A series of indentation fixes

### DIFF
--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -52,7 +52,7 @@ function! GetNixIndent()
       return indent(bslnum)
     endif
 
-    if last_line =~ ';$'
+    if last_line =~ ';\s*$'
       let bslnum = searchpair(s:binding_open, '', s:binding_close, 'bnW',
             \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "StringSpecial$"')
       if bslnum != 0

--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -76,7 +76,7 @@ function! GetNixIndent()
       let ind += &sw
     endif
 
-    if getline(v:lnum - 1) =~ '^\<in\s*$'
+    if last_line =~ '^\<in\s*$'
       let ind += &sw
     endif
 

--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -9,7 +9,7 @@ endif
 let b:did_indent = 1
 
 setlocal indentexpr=GetNixIndent()
-setlocal indentkeys+=0=then,0=else,0=inherit,*<Return>
+setlocal indentkeys+=0=then,0=else,0=inherit,0=in,*<Return>
 
 if exists("*GetNixIndent")
   finish

--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -52,7 +52,7 @@ function! GetNixIndent()
       return indent(bslnum)
     endif
 
-    if last_line =~ ';\s*$'
+    if last_line =~ ';\s*$' && current_line !~ s:binding_open
       let bslnum = searchpair(s:binding_open, '', s:binding_close, 'bnW',
             \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "StringSpecial$"')
       if bslnum != 0

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -418,6 +418,19 @@ Execute (syntax):
   AssertEqual SyntaxOf('foo'), 'nixFunctionCall'
   AssertEqual SyntaxOf('withfoo'), 'nixFunctionCall'
 
+Given nix (with-newline-let-staircase-bug):
+Do (with-newline-let-staircase-bug):
+  iwith foo;\<Return>\<Return>let\<Return>bar = 111;\<Return>in bar\<Esc>
+
+Expect (indentation):
+~~~~~~~
+  with foo;
+
+  let
+    bar = 111;
+  in bar
+~~~~~~~
+
 Given nix (assert-expr):
   assert true -> false; null
 

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -276,7 +276,18 @@ Expect (indentation):
     inherit (attr) foo;
   in
     foo
+~~~~~~~
 
+Given nix (let-in-indent-sameline):
+Do (let-in-indent-sameline):
+  ilet\<Enter>foo = 111;\<Enter>in foo\<Esc>
+
+Expect (indentation):
+~~~~~~~
+  let
+    foo = 111;
+  in foo
+~~~~~~~
 
 Given nix (builtins):
   builtins.doesntexist (builtins.map id [


### PR DESCRIPTION
This adds tests plus a few fixes for indentation, mainly around `let` bindings.

For example things like this should now be indented correctly:

```nix
with import <nixpkgs> {};

let
  foo = "bar";
in foo
```