### PR TITLE
Don't highlight `$${}` as string interpolation

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -36,6 +36,7 @@ syn region nixInterpolation matchgroup=nixInterpolationDelimiter start="\${" end
 
 syn match nixSimpleStringSpecial /\\\%([nrt"\\$]\|$\)/ contained
 syn match nixStringSpecial /''['$]/ contained
+syn match nixStringSpecial /\$\$/ contained
 syn match nixStringSpecial /''\\[nrt]/ contained
 
 syn match nixInvalidSimpleStringEscape /\\[^nrt"\\$]/ contained

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -365,6 +365,7 @@ Given nix (multiline-string-escape):
   ''
     foo'''bar''\nend
     ''${xxx}
+    $${foo}
   ''
 
 Execute (syntax):
@@ -377,6 +378,8 @@ Execute (syntax):
   AssertEqual SyntaxOf('{'), 'nixString'
   AssertEqual SyntaxOf('xxx'), 'nixString'
   AssertEqual SyntaxOf('}'), 'nixString'
+  AssertEqual SyntaxOf('\$\$'), 'nixStringSpecial'
+  AssertEqual SyntaxOf('{foo}'), 'nixString'
 
 Given nix (string-escape-errors):
   ''


### PR DESCRIPTION
Double dollar signs in Nix strings evaluate to a two dollar
signs rather than a dollar and a string interpolation:

```
Welcome to Nix version 2.1.3. Type :? for help.

nix-repl> ''
          $${foo}
          ''
"$${foo}\n"
```