### PR TITLE
Initial work for fenced language syntaxes

### DIFF
--- a/ftplugin/nix.vim
+++ b/ftplugin/nix.vim
@@ -19,3 +19,116 @@ if get(g:, 'nix_recommended_style', 1)
     \ softtabstop=2
     \ expandtab 
 endif
+
+" Borrowed from vim-markdown: https://github.com/plasticboy/vim-markdown/
+if exists('g:vim_nix_fenced_languages')
+    let s:filetype_dict = {}
+    for s:filetype in g:vim_markdown_fenced_languages
+        let key = matchstr(s:filetype, "[^=]*")
+        let val = matchstr(s:filetype, "[^=]*$")
+        let s:filetype_dict[key] = val
+    endfor
+else
+    let s:filetype_dict = {
+        \ 'c++': 'cpp',
+        \ 'viml': 'vim',
+        \ 'bash': 'sh',
+        \ 'ini': 'dosini'
+    \ }
+endif
+
+function! s:NixHighlightSources(force)
+    " Syntax highlight source code embedded in notes.
+    " Look for code blocks in the current file
+    let filetypes = {}
+    for line in getline(1, '$')
+        let ft = matchstr(line, "/\\*\\s*\\zs[0-9A-Za-z_+-]*\\ze\\s*\\*/\\s*''")
+        if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
+    endfor
+    if !exists('b:nix_known_filetypes')
+        let b:nix_known_filetypes = {}
+    endif
+    if !exists('b:nix_included_filetypes')
+        " set syntax file name included
+        let b:nix_included_filetypes = {}
+    endif
+    if !a:force && (b:nix_known_filetypes == filetypes || empty(filetypes))
+        return
+    endif
+
+    " Now we're ready to actually highlight the code blocks.
+    for ft in keys(filetypes)
+        if a:force || !has_key(b:nix_known_filetypes, ft)
+            if has_key(s:filetype_dict, ft)
+                let filetype = s:filetype_dict[ft]
+            else
+                let filetype = ft
+            endif
+            let group = 'nixSnippet' . toupper(substitute(filetype, "[+-]", "_", "g"))
+            if !has_key(b:nix_included_filetypes, filetype)
+                let include = s:SyntaxInclude(filetype)
+                let b:nix_included_filetypes[filetype] = 1
+            else
+                let include = '@' . toupper(filetype)
+            endif
+            let command = "syn region %s matchgroup=nixCodeStart start=@/\\*\\s*%s\\s*\\*/\\s*''@ matchgroup=NONE skip=+''['$\\\\]+ matchgroup=nixCodeEnd end=+''+ keepend extend contains=nixInterpolation,nixStringSpecial,nixInvalidStringEscape,%s"
+            execute printf(command, group, ft, include)
+            execute printf("syn cluster nixExpr add=%s", group)
+	    execute printf("syn region nixInterpolation matchgroup=nixInterpolationDelimiter start=+\\(''\\)\\@<!\\${+ end=+}+ containedin=%s contains=@nixExpr,nixInterpolationParam", include)
+	    execute printf("syn match nixStringSpecial /''\\$/me=e-1 containedin=%s", include)
+	    execute printf("syn match nixStringSpecial /'''/me=e-2 containedin=%s", include)
+	    execute printf("syn match nixStringSpecial /''\\\\[nrt]/ containedin=%s", include)
+	    execute printf("syn match nixInvalidStringEscape /''\\\\[^nrt]/ containedin=%s", include)
+
+            let b:nix_known_filetypes[ft] = 1
+        endif
+    endfor
+endfunction
+
+function! s:SyntaxInclude(filetype)
+    " Include the syntax highlighting of another {filetype}.
+    let grouplistname = '@' . toupper(a:filetype)
+    " Unset the name of the current syntax while including the other syntax
+    " because some syntax scripts do nothing when "b:current_syntax" is set
+    if exists('b:current_syntax')
+        let syntax_save = b:current_syntax
+        unlet b:current_syntax
+    endif
+    try
+        execute 'syntax include' grouplistname 'syntax/' . a:filetype . '.vim'
+        execute 'syntax include' grouplistname 'after/syntax/' . a:filetype . '.vim'
+    catch /E484/
+        " Ignore missing scripts
+    endtry
+    " Restore the name of the current syntax
+    if exists('syntax_save')
+        let b:current_syntax = syntax_save
+    elseif exists('b:current_syntax')
+        unlet b:current_syntax
+    endif
+    return grouplistname
+endfunction
+
+
+function! s:NixRefreshSyntax(force)
+    if &filetype =~ 'nix' && line('$') > 1
+        call s:NixHighlightSources(a:force)
+    endif
+endfunction
+
+function! s:NixClearSyntaxVariables()
+    if &filetype =~ 'nix'
+        unlet! b:nix_included_filetypes
+    endif
+endfunction
+
+augroup Nix
+    " These autocmd calling s:NixRefreshSyntax need to be kept in sync with
+    " the autocmds calling s:NixSetupFolding in after/ftplugin/markdown.vim.
+    autocmd! * <buffer>
+    autocmd BufWinEnter <buffer> call s:NixRefreshSyntax(1)
+    autocmd BufUnload <buffer> call s:NixClearSyntaxVariables()
+    autocmd BufWritePost <buffer> call s:NixRefreshSyntax(0)
+    autocmd InsertEnter,InsertLeave <buffer> call s:NixRefreshSyntax(0)
+    autocmd CursorHold,CursorHoldI <buffer> call s:NixRefreshSyntax(0)
+augroup END

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -44,6 +44,7 @@ syn match nixInvalidStringEscape /''\\[^nrt]/ contained
 
 syn region nixSimpleString matchgroup=nixStringDelimiter start=+"+ skip=+\\"+ end=+"+ contains=nixInterpolation,nixSimpleStringSpecial,nixInvalidSimpleStringEscape
 syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ end=+''+ contains=nixInterpolation,nixStringSpecial,nixInvalidStringEscape
+syn region nixFencedString matchgroup=nixCodeStart start=+/\*\s*[0-9A-Za-z_+-]*\s*\*/\s*''+ skip=+''['$\\]+ matchgroup=nixCodeEnd end=+''+ keepend extend contains=nixInterpolation,nixStringSpecial,nixInvalidStringEscape
 
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 
@@ -159,6 +160,8 @@ hi def link nixAttribute                 Identifier
 hi def link nixAttributeDot              Operator
 hi def link nixBoolean                   Boolean
 hi def link nixBuiltin                   Special
+hi def link nixCodeEnd                   Delimiter
+hi def link nixCodeStart                 Delimiter
 hi def link nixComment                   Comment
 hi def link nixConditional               Conditional
 hi def link nixHomePath                  Include
@@ -183,6 +186,7 @@ hi def link nixSimpleFunctionArgument    Identifier
 hi def link nixSimpleString              String
 hi def link nixSimpleStringSpecial       SpecialChar
 hi def link nixString                    String
+hi def link nixFencedString              String
 hi def link nixStringDelimiter           Delimiter
 hi def link nixStringSpecial             Special
 hi def link nixTodo                      Todo

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -1,3 +1,7 @@
+Before:
+  unlet! b:nix_known_filetypes
+  unlet! b:nix_included_filetypes
+
 Given nix (attribute):
   {
     foo = pkgs.callPackage ./examples/foo {};
@@ -187,6 +191,73 @@ Expect (indentation):
     baz
   ''
 ~~~~~~~
+
+Given nix (fenced-multiline-string):
+  /* vim */ ''
+    line1 ${ref1}
+    ${ref2} line2
+    line3 ${ref3}
+  '';
+
+Execute (syntax):
+  AssertEqual SyntaxOf('vim'), 'nixCodeStart'
+  AssertEqual SyntaxOf('line1'), 'nixFencedString'
+  AssertEqual SyntaxOf('line2'), 'nixFencedString'
+  AssertEqual SyntaxOf('line3'), 'nixFencedString'
+  AssertEqual SyntaxOf('ref1'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref2'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref3'), 'nixInterpolationParam'
+
+Given nix (fenced-multiline-string):
+  {
+    c = /* c++ */ ''
+      #include <iostream>
+      code
+    '';
+
+    v = /* vim */ ''
+      set bg=dark
+    '';
+
+    s = /* sh */ ''
+      ${ref1}
+      ''${ref2}
+      echo ${ref3}
+      echo ''${ref4}
+    '';
+  }
+
+Execute (syntax):
+  let b:func = Nix_GetFunc('ftplugin/nix.vim', 'NixRefreshSyntax')
+  call b:func(0)
+  AssertEqual SyntaxOf('c++'), 'nixCodeStart'
+  AssertEqual SyntaxOf('include'), 'cInclude'
+  AssertEqual SyntaxOf('code'), 'nixSnippetCPP'
+  AssertEqual SyntaxOf('set'), 'vimCommand'
+  AssertEqual SyntaxOf('ref1'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref2'), 'shDerefVar'
+  AssertEqual SyntaxOf('ref3'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('ref4'), 'shDerefVar'
+
+Given nix (fenced-multiline-string-specials):
+  /* sh */ ''
+    '''
+    ''\n
+    ''\f
+    $$
+    ''$
+  '';
+
+Execute (syntax):
+  let b:func = Nix_GetFunc('ftplugin/nix.vim', 'NixRefreshSyntax')
+  call b:func(0)
+  AssertEqual SyntaxOf("'''"), 'nixStringSpecial'
+  AssertEqual SyntaxAt(2, 4), 'shQuote'
+  AssertEqual SyntaxAt(2, 5), 'shQuote'
+  AssertEqual SyntaxOf('\\n'), 'nixStringSpecial'
+  AssertEqual SyntaxOf('\\f'), 'nixInvalidStringEscape'
+  AssertEqual SyntaxOf('$$'), 'shDerefSimple'
+  AssertEqual SyntaxOf('\$', 3), 'nixSnippetSH'
 
 Given nix (url):
   https://github.com/LnL7/vim-nix


### PR DESCRIPTION
I'm sure there's optimizations to be done, probably some visual bugs, but this adds fenced syntax highlighting to Nix files by making use of a leading comment on multiline strings.
```nix
{
  installPhase = /* sh */ ''
    mkdir -p $out
    cp -r ftdetect ftplugin indent syntax $out
  '';

  vimrc = writeText "vimrc" /* vim */ ''
    filetype off
    set rtp+=${vader}
    set rtp+=${src}
   '';
}
```
![image](https://user-images.githubusercontent.com/630909/64119213-42f21e00-cd67-11e9-955f-847ad5e0b2e5.png)

