### PR TITLE
Use setfiletype instead of set filetype

### DIFF
--- a/ftdetect/nix.vim
+++ b/ftdetect/nix.vim
@@ -3,4 +3,4 @@
 " Maintainer:  Daiderd Jordan <daiderd@gmail.com>
 " URL:         https://github.com/LnL7/vim-nix
 
-au BufRead,BufNewFile *.nix set filetype=nix
+au BufRead,BufNewFile *.nix setf nix


### PR DESCRIPTION
Hi,

This is kind of hard to explain, and I can't really point to the right location in the docs that explains this, but the TL;DR of this change is:

Enable me to add something like this to my `filetype.vim`

```vim
" Nixpkgs
au BufNewFile,BufRead /var/src/nixpkgs/** setf nix.nixpkgs
```

(While I set some extra settings to `ftplugin/nixpkgs.vim`).

I've learned about this subtlety at https://github.com/neomutt/neomutt.vim/pull/4 .