### PR TITLE
Removed iskeyword set in setlocal

### DIFF
--- a/ftplugin/nix.vim
+++ b/ftplugin/nix.vim
@@ -11,7 +11,6 @@ let b:did_ftplugin = 1
 setlocal
   \ comments=:#
   \ commentstring=#\ %s
-  \ iskeyword+=-
 
 if get(g:, 'nix_recommended_style', 1)
   setlocal


### PR DESCRIPTION
fixes #35.

1. for my taste this is too sensitive vim variable for the global crowd. especially when you set a habit of moving around with keystrokes and expectation where the cursor will land.

2. completion by word as well confusing with this setting.