### PR TITLE
nixExpr: highlight `args@{ ... }` in an assignment

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -120,7 +120,7 @@ syn region nixWithExpr matchgroup=nixWithExprKeyword start="\<with\>" matchgroup
 
 syn region nixAssertExpr matchgroup=nixAssertKeyword start="\<assert\>" matchgroup=NONE end=";" contains=@nixExpr
 
-syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixRecKeyword,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathRef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr,nixInterpolation
+syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixRecKeyword,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixArgOperator,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathRef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr,nixInterpolation
 
 " These definitions override @nixExpr and have to come afterwards:
 


### PR DESCRIPTION
To reproduce the original issue:

The expression

    let
      foo = args@{ ... }: args;
    in foo

doesn't get highlighted, whereas

    let
      foo = { ... }@args: args;
    in foo

does.

The issue is that `nixArgOperator` should be matchable right in the
cluster `nixExpr` which is used when an assignment in an attr-set or a
`let-in` expression happens. It's ensured that only correct syntax
syntax gets highlighted since `nixArgOperator` requires
`nixFunctionArgument` after that.

cc @Lnl7