### PR TITLE
Interpret flake.lock files as JSON

### DIFF
--- a/ftdetect/nix.vim
+++ b/ftdetect/nix.vim
@@ -4,3 +4,4 @@
 " URL:         https://github.com/LnL7/vim-nix
 
 au BufRead,BufNewFile *.nix setf nix
+au BufRead,BufNewFile flake.lock setf json


### PR DESCRIPTION
Nix flakes use lock files named `flake.lock`, which vim currently
interprets as a plain text file. This commit adds an auto command that
sets the `filetype` of files named `flake.lock` to `json`.