### PR TITLE
Highlight `builtins.{floor,ceil}`

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -148,7 +148,7 @@ syn keyword nixNamespacedBuiltin contained
       \ storeDir storePath stringLength sub substring tail throw toFile toJSON
       \ toPath toString toXML trace tryEval typeOf unsafeDiscardOutputDependency
       \ unsafeDiscardStringContext unsafeGetAttrPos valueSize fromTOML bitAnd
-      \ bitOr bitXor
+      \ bitOr bitXor floor ceil
 
 syn match nixBuiltin "builtins\.[a-zA-Z']\+"he=s+9 contains=nixComment,nixNamespacedBuiltin
 


### PR DESCRIPTION
Both are valid Nix 2.4 builtins.

cc @LnL7 