### PR TITLE
syntax: `$${}` is also an escape in simple-string contexts

### DIFF
--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -39,6 +39,8 @@ syn match nixStringSpecial /''['$]/ contained
 syn match nixStringSpecial /\$\$/ contained
 syn match nixStringSpecial /''\\[nrt]/ contained
 
+syn match nixSimpleStringSpecial /\$\$/ contained
+
 syn match nixInvalidSimpleStringEscape /\\[^nrt"\\$]/ contained
 syn match nixInvalidStringEscape /''\\[^nrt]/ contained
 


### PR DESCRIPTION
To demonstrate what I'm talking about:

    $ nix repl
    Welcome to Nix 2.7.0. Type :? for help.

    nix-repl> a = "foo"

    nix-repl> "${a}"
    "foo"

    nix-repl> "''${a}"
    "''foo"

    nix-repl> "$${a}"
    "$${a}"

    nix-repl> "\$${a}"
    "$foo"

    nix-repl> "\${a}"
    "${a}"

This change ensures that each expression is highlighted properly in VIM.
The primary issue was that `$${...}` was mistakenly highlighted as
string interpolation.

cc @LnL7 