### PR TITLE
indent: don't do anything if current line is indented more then previous line

### DIFF
--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -33,6 +33,11 @@ function! GetNixIndent()
     return 0
   endif
 
+  let current = indent(v:lnum)
+  if current > ind
+    return current
+  endif
+
   " Skip indentation for single line comments explicitly, in case a
   " comment was just inserted (eg. visual block mode)
   if getline(v:lnum) =~ '^\s*#'


### PR DESCRIPTION
Typical example

    {
      attr = map
        f|
    }

with | being the cursor. When entering <CR>, the code looks like this:

    {
      attr = map
      f
      |
    }

I.e. the (intentional) indentation of `f` was undone. This frequently happens because I indent a lot of expressions like this, for instance

    map
      f
      xs

or

    if cond
      then x1
      else x2

This has a few drawbacks, for instance bogus indentation now causes follow-up errors, e.g.

    map
      f
      [
        1
          2
      ]|

on <CR> causes

    map
      f
      [
        1
          2
        ]
        |

however, in that case the indent is already bogus.