### PR TITLE
syntax: correctly highlight paths with interpolation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,9 @@ stdenv.mkDerivation rec {
     endfunction
 
     command! Syntax call Syntax()
+
+    set backspace=2
+    set hlsearch
   '';
 
   checkPhase = ''

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -50,7 +50,7 @@ syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ en
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 
 syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
-syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze\%(${\)" skip="[a-zA-Z0-9._+/-]*\ze${" end="\%(}\)\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation
+syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze${" skip="[a-zA-Z0-9._+/-]*\ze${" end="}\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation
 syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
 syn match nixPathDelimiter "[<>]" contained

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -50,7 +50,7 @@ syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ en
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 
 syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
-syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze\%(${\)" skip="[a-zA-Z0-9._+/-]*\ze${" end="\%(}\)\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation oneline
+syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze\%(${\)" skip="[a-zA-Z0-9._+/-]*\ze${" end="\%(}\)\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation
 syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
 syn match nixPathDelimiter "[<>]" contained

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -50,6 +50,7 @@ syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ en
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 
 syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
+syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze\%(${\)" skip="[a-zA-Z0-9._+/-]*\ze${" end="\%(}\)\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation oneline
 syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
 syn match nixPathDelimiter "[<>]" contained
@@ -123,7 +124,7 @@ syn region nixWithExpr matchgroup=nixWithExprKeyword start="\<with\>" matchgroup
 
 syn region nixAssertExpr matchgroup=nixAssertKeyword start="\<assert\>" matchgroup=NONE end=";" contains=@nixExpr
 
-syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixRecKeyword,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixArgOperator,nixSimpleFunctionArgument,nixPath,nixHomePath,nixSearchPathRef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr,nixInterpolation
+syn cluster nixExpr contains=nixBoolean,nixNull,nixOperator,nixParen,nixInteger,nixRecKeyword,nixConditional,nixBuiltin,nixSimpleBuiltin,nixComment,nixFunctionCall,nixFunctionArgument,nixArgOperator,nixSimpleFunctionArgument,nixInterpolatedPath,nixPath,nixHomePath,nixSearchPathRef,nixURI,nixAttributeSet,nixList,nixSimpleString,nixString,nixLetExpr,nixIfExpr,nixWithExpr,nixAssertExpr,nixInterpolation
 
 " These definitions override @nixExpr and have to come afterwards:
 
@@ -179,6 +180,7 @@ hi def link nixNamespacedBuiltin         Special
 hi def link nixNull                      Constant
 hi def link nixOperator                  Operator
 hi def link nixPath                      Include
+hi def link nixInterpolatedPath          nixPath
 hi def link nixPathDelimiter             Delimiter
 hi def link nixRecKeyword                Keyword
 hi def link nixSearchPath                Include

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -50,7 +50,7 @@ syn region nixString matchgroup=nixStringDelimiter start=+''+ skip=+''['$\\]+ en
 syn match nixFunctionCall "[a-zA-Z_][a-zA-Z0-9_'-]*"
 
 syn match nixPath "[a-zA-Z0-9._+-]*\%(/[a-zA-Z0-9._+-]\+\)\+"
-syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)\%(\/[a-zA-Z0-9._+/-]\+\|\/\)\ze${" skip="[a-zA-Z0-9._+/-]*\ze${" end="}\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation
+syn region nixInterpolatedPath start="\%(\~\|[a-zA-Z0-9._+-]*\)/[a-zA-Z0-9._+/-]*\ze${" skip="[a-zA-Z0-9._+/-]*\ze${" end="}\@<=[a-zA-Z0-9._+/-]*\%([^a-zA-Z0-9._+/-]\|$\)\@=" contains=nixInterpolation
 syn match nixHomePath "\~\%(/[a-zA-Z0-9._+-]\+\)\+"
 syn match nixSearchPath "[a-zA-Z0-9._+-]\+\%(\/[a-zA-Z0-9._+-]\+\)*" contained
 syn match nixPathDelimiter "[<>]" contained

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -234,6 +234,167 @@ Execute (syntax):
   AssertEqual SyntaxOf('\./\.'), 'nixPath'
   AssertEqual SyntaxOf('/etc/passwd'), 'nixPath'
 
+Given nix (path-with-interpolation-simple):
+  ./snens/${bar}/baz
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('/baz'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 8), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 15), 'nixInterpolatedPath'
+
+Given nix (path-with-interpolation-in-path-part):
+  ./snens/${bar}kek/end
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('/end'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 8), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 14), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 15), 'nixInterpolatedPath'
+
+Given nix (path-with-interpolation-and-prefix):
+  ./snens/pre${bar}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 8), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 12), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+
+Given nix (path-with-interpolation-suffix):
+  ./snens/pre${bar}suff
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 8), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 12), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('suff'), 'nixInterpolatedPath'
+
+Given nix (path-with-interpolation-in-mid-part):
+  ./snens/pre${bar}/kek
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('/kek'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+
+Given nix (path-with-multiple-interpolations):
+  ./snens/${bar}${baz}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 20), 'nixInterpolationDelimiter'
+
+Given nix (path-with-multiple-interpolations-and-infix):
+  ./snens/${bar}in${baz}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('in'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 22), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 14), 'nixInterpolationDelimiter'
+
+Given nix (path-with-multiple-interpolations-and-suffix):
+  ./snens/${bar}in${baz}suff
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('in'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 22), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 14), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('suff'), 'nixInterpolatedPath'
+
+Execute (syntax):
+
+Given nix (path-with-multiple-interpolations-and-prefix):
+  ./snens/pre${bar}in${baz}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 12), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('in'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 20), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 25), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+
+Given nix (path-with-multiple-interpolations-and-dir-suffix):
+  ./snens/${bar}in${baz}/suff
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('in'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 17), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 22), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 14), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 23), 'nixInterpolatedPath'
+
+Given nix (path-with-multiple-interpolations-in-separate-dirs):
+  ./snens/${bar}/${baz}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 16), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('baz'), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 21), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 14), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 15), 'nixInterpolatedPath'
+
+Given nix (homepath-with-interpolation):
+  ~/${snens}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('\~/'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('snens'), 'nixInterpolationParam'
+
+Given nix (path-with-invalid-infix):
+  ./snens/${bar}in!${baz}
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 8), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixInterpolationParam'
+  AssertEqual SyntaxOf('in'), 'nixInterpolatedPath'
+# invalid syntax. Just make sure this isn't misinterpreted as a path.
+  AssertEqual SyntaxOf('!'), 'nixOperator'
+  AssertEqual SyntaxAt(1, 18), ''
+  AssertEqual SyntaxOf('baz'), 'nixArgumentDefinition'
+
+Given nix (path-with-recursive-interpolation):
+  ./snens/${bar.${baz}}/suff
+
+Execute (syntax):
+  AssertEqual SyntaxOf('./snens'), 'nixInterpolatedPath'
+  AssertEqual SyntaxAt(1, 9), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 15), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 21), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxAt(1, 11), 'nixInterpolationParam'
+  AssertEqual SyntaxAt(1, 22), 'nixInterpolatedPath'
+
 Given nix (let):
   let
     foo = true;

--- a/test/nix.vader
+++ b/test/nix.vader
@@ -395,6 +395,18 @@ Execute (syntax):
   AssertEqual SyntaxAt(1, 11), 'nixInterpolationParam'
   AssertEqual SyntaxAt(1, 22), 'nixInterpolatedPath'
 
+Given nix (path-with-multiline-subexpr):
+  foo/${
+    "bar"
+  }
+
+Execute (syntax):
+  AssertEqual SyntaxOf('foo/'), 'nixInterpolatedPath'
+  AssertEqual SyntaxOf('${'), 'nixInterpolationDelimiter'
+  AssertEqual SyntaxOf('"'), 'nixStringDelimiter'
+  AssertEqual SyntaxOf('bar'), 'nixSimpleString'
+  AssertEqual SyntaxOf('}'), 'nixInterpolationDelimiter'
+
 Given nix (let):
   let
     foo = true;


### PR DESCRIPTION
OK I nerdsniped myself into doing that now, damn it :upside_down_face: 
Anyways, this is a draft on purpose, because there's one known case of a wrong highlight (see commit message below) and I haven't tested this under real conditions yet.
cc @LnL7 @figsoda @aszlig 

------
Closes https://github.com/LnL7/vim-nix/issues/41

A few implementation notes:

* `nixInterpolatedPath` is on purpose below `nixPath`, otherwise the
  highlighting of top-level expressions, i.e. files containing e.g.

      ./foo/bar${baz}

  break where `$` is entirely unmatched and `{baz}` is misinterpreted as
  argument destructuring expression.

* The region's matching behavior now works like this:

  First, we expect a path start (i.e. either `~/<further path components>`
  or `<path components>`) and then the beginning of a substitution (`${`), however
  this isn't part of our match anymore (hence `\ze`) to make sure this
  is matched by the subsequent `nixInterpolation`.

  Also, `nixInterpolation` is the only thing allowed in here because
  `nixPath` would conflict with our `end` & `skip` expression and would
  thus make vim expand the `nixInterpolatedPath` over the rest of the
  file.

  To summarize, after the start, two things are allowed:

  * An interpolation
  * Valid path chars.

  The `skip` regex is to make sure that the `end` isn't satisified too
  early, e.g. in

      ./foo/${bar}/${baz}/suff

  the path shouldn't terminate after `${bar}/` since another
  substitution is followed by only valid path chars.

  The end regex makes sure that the last substitution was closed
  (`nixinterpolatedPath` always contains a substitution because of
  `start`) and only valid path chars are matched after that. This means
  that e.g. in

      ./foo/${bar}!x

  everything after `${bar}` is not part of the path anymore.

* In the end a region turned out to be slightly more suitable, so this
  cannot be composed into a single group with the matcher `nixPath`.

  Instead, `nixInterpolatedPath`'s highlighting group now links to
  `nixPath` to make sure they look the same in the end.