### PR TITLE
syntax/nix: autogenerate namespaced builtins from `nix __dump-language`

### DIFF
--- a/builtins.sh
+++ b/builtins.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash jq nix
+
+header="syn keyword nixNamespacedBuiltin contained"
+
+nix __dump-language | jq -r '
+  def to_vim: keys | map("  \\ " + . + "\n") | .[];
+  [ (.builtins | to_vim)
+  , (.constants | del(.["true","false","null","builtins"]) | to_vim)
+  ] | add
+' | sed -n -i -e '/^'"$header"'/ {
+  p; n; r /dev/stdin
+  :l; n; /^$/!bl; b
+}; p' syntax/nix.vim

--- a/syntax/nix.vim
+++ b/syntax/nix.vim
@@ -137,22 +137,112 @@ syn keyword nixSimpleBuiltin
       \ scopedImport throw toString
 
 
+" Generated automatically: use `./builtins.sh` from the repo's root to update.
 " Namespaced and non-namespaced Nix builtins as of version 2.0:
 syn keyword nixNamespacedBuiltin contained
-      \ abort add addErrorContext all any attrNames attrValues baseNameOf
-      \ catAttrs compareVersions concatLists concatStringsSep currentSystem
-      \ currentTime deepSeq derivation derivationStrict dirOf div elem elemAt
-      \ fetchGit fetchMercurial fetchTarball fetchurl filter \ filterSource
-      \ findFile foldl' fromJSON functionArgs genList \ genericClosure getAttr
-      \ getEnv hasAttr hasContext hashString head import intersectAttrs isAttrs
-      \ isBool isFloat isFunction isInt isList isNull isString langVersion
-      \ length lessThan listToAttrs map mapAttrs match mul nixPath nixVersion
-      \ parseDrvName partition path pathExists placeholder readDir readFile
-      \ removeAttrs replaceStrings scopedImport seq sort split splitVersion
-      \ storeDir storePath stringLength sub substring tail throw toFile toJSON
-      \ toPath toString toXML trace tryEval typeOf unsafeDiscardOutputDependency
-      \ unsafeDiscardStringContext unsafeGetAttrPos valueSize fromTOML bitAnd
-      \ bitOr bitXor floor ceil
+  \ abort
+  \ add
+  \ all
+  \ any
+  \ attrNames
+  \ attrValues
+  \ baseNameOf
+  \ bitAnd
+  \ bitOr
+  \ bitXor
+  \ break
+  \ catAttrs
+  \ ceil
+  \ compareVersions
+  \ concatLists
+  \ concatMap
+  \ concatStringsSep
+  \ deepSeq
+  \ dirOf
+  \ div
+  \ elem
+  \ elemAt
+  \ fetchClosure
+  \ fetchGit
+  \ fetchTarball
+  \ fetchurl
+  \ filter
+  \ filterSource
+  \ findFile
+  \ flakeRefToString
+  \ floor
+  \ foldl'
+  \ fromJSON
+  \ fromTOML
+  \ functionArgs
+  \ genList
+  \ genericClosure
+  \ getAttr
+  \ getContext
+  \ getEnv
+  \ getFlake
+  \ groupBy
+  \ hasAttr
+  \ hasContext
+  \ hashFile
+  \ hashString
+  \ head
+  \ import
+  \ intersectAttrs
+  \ isAttrs
+  \ isBool
+  \ isFloat
+  \ isFunction
+  \ isInt
+  \ isList
+  \ isNull
+  \ isPath
+  \ isString
+  \ length
+  \ lessThan
+  \ listToAttrs
+  \ map
+  \ mapAttrs
+  \ match
+  \ mul
+  \ outputOf
+  \ parseDrvName
+  \ parseFlakeRef
+  \ partition
+  \ path
+  \ pathExists
+  \ placeholder
+  \ readDir
+  \ readFile
+  \ readFileType
+  \ removeAttrs
+  \ replaceStrings
+  \ seq
+  \ sort
+  \ split
+  \ splitVersion
+  \ storePath
+  \ stringLength
+  \ sub
+  \ substring
+  \ tail
+  \ throw
+  \ toFile
+  \ toJSON
+  \ toPath
+  \ toString
+  \ toXML
+  \ trace
+  \ traceVerbose
+  \ tryEval
+  \ typeOf
+  \ zipAttrsWith
+  \ currentSystem
+  \ currentTime
+  \ langVersion
+  \ nixPath
+  \ nixVersion
+  \ storeDir
 
 syn match nixBuiltin "builtins\.[a-zA-Z']\+"he=s+9 contains=nixComment,nixNamespacedBuiltin
 


### PR DESCRIPTION
We had quite a bunch of changes in the past that added builtins to get them highlighted properly[1].

Nowadays it's possible to get this from Nix itself by running `nix __dump-language`. This was done on a recent Nix and includes all experimental features by default[2] which seems fine to me since this is not an LSP, but only an approximation.

This patch adds a few new builtins, e.g. `break` and `flakeRefToString` and a script to regenerate the list.

This doesn't include non-scoped builtins (e.g. `map`, `baseNameOf` etc.), but those are added far less frequent, so this seems OK to me.

Also, there are a few hidden builtins, most notably `unsafe*` and `scopedImport`. I think this was done on purpose by upstream and I'm wondering if we should adhere to that approach. If we still want to keep those, I think we should add those to a custom highlighting group that's maintained manually.

[1] #44, #42, #36, #32, 711aaf7edfd1d04bb981871f53ffec2b62f79b15
[2] https://github.com/NixOS/nix/blob/2.20.1/src/nix/main.cc#L372

cc @LnL7 @aszlig for opinions