### PR TITLE
Indent improvements

### DIFF
--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -60,10 +60,6 @@ function! GetNixIndent()
       let ind -= &sw
     endif
 
-    if last_line =~ '[(=]$'
-      let ind += &sw
-    endif
-
     if last_line =~ '\<let\s*$'
       let ind += &sw
     endif

--- a/indent/nix.vim
+++ b/indent/nix.vim
@@ -21,8 +21,9 @@ set cpo&vim
 let s:skip_syntax = '\%(Comment\|String\)$'
 let s:binding_open = '\%(\<let\>\)'
 let s:binding_close = '\%(\<in\>\)'
-let s:block_open  = '\%({\|[\)'
-let s:block_close = '\%(}\|]\)'
+
+let s:block_open  = '\%({\|[\|(\)'
+let s:block_close = '\%(}\|]\|)\)'
 
 function! GetNixIndent()
   let lnum = prevnonblank(v:lnum - 1)


### PR DESCRIPTION
The first commit has a detailed description, I recommend reading it. I'd love to improve it before merging, since it does regress in a few areas.

Quick question: the multiline string indentation wasn't working for me. I'm using treesitter through nvim, and so wasn't getting my highlighting through `:syntax on`, so it didn't detect the `synIDAttr`. We could just remove the wrapping `if` statement, and check for `''` generically. However, that would technically cause some regressions if there was a literal `''` within some double quotes. What do you think is the best fix here? I can maintain a local patch if necessary.